### PR TITLE
fix proxying urls containing space

### DIFF
--- a/init.php
+++ b/init.php
@@ -79,7 +79,7 @@ class af_https_proxy_assets extends Plugin
 	function proxy()
 	{
 		//$target_url = $_REQUEST['url'];
-		$target_url = urldecode( $_REQUEST['url'] );
+		$target_url = str_replace(' ', '%20', urldecode( $_REQUEST['url'] ));
 		$client = new PhCURL('http://' . $target_url);
 		$client->loadCommonSettings();
 		$client->enableBinaryTransfer(true);


### PR DESCRIPTION
I encountered a bug when proxying images whose url contain a space.
This is a hack to fix it.
I have no idea whether a similar bug exists with other special characters, and anyway my php abilities are not sufficient to implement any more complex workaround.